### PR TITLE
feat(auth): follow-up  absolute expiry, members API, plan mirror, act…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ npm run dev
 - `npx convex deploy` → Deploy schema + functions to production. 
   (This is the command Vercel also runs during builds.)
 
+## IMPORTANT
+## Convex Dev Database Sync
+
+chmod +x sync-dev.sh
+
+Convex does not automatically sync the **Dev** database with **Prod** unles you bash / chmod +x sync-dev.sh   
+To test locally with realistic data, you need to refresh Dev from Prod.
+
+### One-time export/import
+Run these commands in the project root:
+
+```bash
+# Export all data from Prod into a zip file
+npx convex export --deployment-name prod:upbeat-hedgehog-998 --path prod.zip
+
+# Import that data into Dev (this will overwrite Dev DB!)
+npx convex import --deployment-name dev:adorable-chicken-923 --replace prod.zip
+
+
 ---
 
 ## Environment Variables
@@ -201,5 +220,10 @@ Add the following to your `.env.local` (documented here for local setup):
 ```
 NEXT_PUBLIC_HEARTBEAT_SECONDS=60
 SESSION_IDLE_MINUTES=15
+SESSION_ABSOLUTE_MINUTES=480
 ```
+
+Notes:
+- SESSION_IDLE_MINUTES controls inactivity timeout (minutes).
+- SESSION_ABSOLUTE_MINUTES enforces a hard max session lifetime (minutes). Set to 0 to disable.
 

--- a/src/app/api/cliqs/[id]/join/route.ts
+++ b/src/app/api/cliqs/[id]/join/route.ts
@@ -23,16 +23,14 @@
  *   - 500 on error
  */
 export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '@/lib/auth/getCurrentUser';
 import { validateAgeRequirements } from '@/lib/utils/ageUtils';
 import { convexHttp } from '@/lib/convex-server';
 import { api } from 'convex/_generated/api';
-import { cookies } from 'next/headers';
-import { getIronSession } from 'iron-session';
-import { sessionOptions, SessionData } from '@/lib/auth/session-config';
-import { invalidateUser } from '@/lib/cache/userCache';
+import { bumpActivityAndInvalidate } from '@/lib/session-activity';
 
 export async function POST(
   req: NextRequest,
@@ -125,17 +123,7 @@ export async function POST(
 
     console.log(`[JOIN_CLIQ_SUCCESS] User ${user.id} joined cliq ${cliqId} (age: ${ageValidation.userAge})`);
     // Bump session activity and invalidate cache
-    try {
-      const cookieStore = await cookies();
-      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
-      const res2 = new Response();
-      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
-      if (session && session.userId) {
-        session.lastActivityAt = Date.now();
-        await session.save();
-        await invalidateUser(String(session.userId));
-      }
-    } catch {}
+    await bumpActivityAndInvalidate();
 
     return NextResponse.json({ 
       success: true,

--- a/src/app/api/cliqs/[id]/leave/route.ts
+++ b/src/app/api/cliqs/[id]/leave/route.ts
@@ -1,0 +1,46 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/getCurrentUser';
+import { convexHttp } from '@/lib/convex-server';
+import { api } from 'convex/_generated/api';
+import { cookies } from 'next/headers';
+import { getIronSession } from 'iron-session';
+import { sessionOptions, SessionData } from '@/lib/auth/session-config';
+import { invalidateUser } from '@/lib/cache/userCache';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: cliqId } = await params;
+    const user = await getCurrentUser();
+    if (!user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    await convexHttp.mutation(api.memberships.leaveCliq, {
+      userId: user.id as any,
+      cliqId: cliqId as any,
+    });
+
+    // Bump activity and invalidate cache
+    try {
+      const cookieStore = await cookies();
+      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
+      const res2 = new Response();
+      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
+      if (session && session.userId) {
+        session.lastActivityAt = Date.now();
+        await session.save();
+        await invalidateUser(String(session.userId));
+      }
+    } catch {}
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[LEAVE_CLIQ_ERROR]', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+

--- a/src/app/api/cliqs/[id]/leave/route.ts
+++ b/src/app/api/cliqs/[id]/leave/route.ts
@@ -1,13 +1,11 @@
 export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '@/lib/auth/getCurrentUser';
 import { convexHttp } from '@/lib/convex-server';
 import { api } from 'convex/_generated/api';
-import { cookies } from 'next/headers';
-import { getIronSession } from 'iron-session';
-import { sessionOptions, SessionData } from '@/lib/auth/session-config';
-import { invalidateUser } from '@/lib/cache/userCache';
+import { bumpActivityAndInvalidate } from '@/lib/session-activity';
 
 export async function POST(
   req: NextRequest,
@@ -24,17 +22,7 @@ export async function POST(
     });
 
     // Bump activity and invalidate cache
-    try {
-      const cookieStore = await cookies();
-      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
-      const res2 = new Response();
-      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
-      if (session && session.userId) {
-        session.lastActivityAt = Date.now();
-        await session.save();
-        await invalidateUser(String(session.userId));
-      }
-    } catch {}
+    await bumpActivityAndInvalidate();
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/src/app/api/cliqs/[id]/member-actions/route.ts
+++ b/src/app/api/cliqs/[id]/member-actions/route.ts
@@ -1,0 +1,74 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/getCurrentUser';
+import { convexHttp } from '@/lib/convex-server';
+import { api } from 'convex/_generated/api';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { getIronSession } from 'iron-session';
+import { sessionOptions, SessionData } from '@/lib/auth/session-config';
+import { invalidateUser } from '@/lib/cache/userCache';
+
+const BodySchema = z.object({
+  targetUserId: z.string().min(1),
+  action: z.enum(['promote', 'demote', 'remove']),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: cliqId } = await params;
+    const user = await getCurrentUser();
+    if (!user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const parsed = BodySchema.safeParse(await req.json());
+    if (!parsed.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+
+    const { targetUserId, action } = parsed.data;
+
+    // Ensure current user is cliq owner
+    const cliq = await convexHttp.query(api.cliqs.getCliqBasic, { cliqId: cliqId as any });
+    if (!cliq || String(cliq.ownerId) !== String(user.id)) {
+      return NextResponse.json({ error: 'Only owner can manage members' }, { status: 403 });
+    }
+
+    if (action === 'remove') {
+      await convexHttp.mutation(api.memberships.removeMember, {
+        userId: targetUserId as any,
+        cliqId: cliqId as any,
+        updatedBy: user.id as any,
+      });
+    } else {
+      const newRole = action === 'promote' ? 'Moderator' : 'Member';
+      await convexHttp.mutation(api.memberships.updateMemberRole, {
+        userId: targetUserId as any,
+        cliqId: cliqId as any,
+        newRole,
+        updatedBy: user.id as any,
+      });
+    }
+
+    // Bump activity and invalidate cache
+    try {
+      const cookieStore = await cookies();
+      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
+      const res2 = new Response();
+      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
+      if (session && session.userId) {
+        session.lastActivityAt = Date.now();
+        await session.save();
+        await invalidateUser(String(session.userId));
+      }
+    } catch {}
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[MEMBER_ACTIONS_ERROR]', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+

--- a/src/app/api/cliqs/[id]/member-actions/route.ts
+++ b/src/app/api/cliqs/[id]/member-actions/route.ts
@@ -39,7 +39,7 @@ export async function POST(
       await convexHttp.mutation(api.memberships.removeMember, {
         userId: targetUserId as any,
         cliqId: cliqId as any,
-        updatedBy: user.id as any,
+        removedBy: user.id as any,
       });
     } else {
       const newRole = action === 'promote' ? 'Moderator' : 'Member';

--- a/src/app/api/cliqs/[id]/members/route.ts
+++ b/src/app/api/cliqs/[id]/members/route.ts
@@ -1,12 +1,11 @@
 export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
 
 import { NextResponse } from 'next/server';
 import { getCurrentUser } from '@/lib/auth/getCurrentUser';
 import { convexHttp } from '@/lib/convex-server';
 import { api } from 'convex/_generated/api';
-import { cookies } from 'next/headers';
-import { getIronSession } from 'iron-session';
-import { sessionOptions, SessionData } from '@/lib/auth/session-config';
+import { bumpActivityAndInvalidate } from '@/lib/session-activity';
 
 export async function GET(
   req: Request,
@@ -23,16 +22,7 @@ export async function GET(
     });
 
     // Count this as activity
-    try {
-      const cookieStore = await cookies();
-      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
-      const res2 = new Response();
-      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
-      if (session && session.userId) {
-        session.lastActivityAt = Date.now();
-        await session.save();
-      }
-    } catch {}
+    await bumpActivityAndInvalidate();
 
     return NextResponse.json({ members: members ?? [] });
   } catch (err) {

--- a/src/app/api/cliqs/[id]/members/route.ts
+++ b/src/app/api/cliqs/[id]/members/route.ts
@@ -1,0 +1,44 @@
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/getCurrentUser';
+import { convexHttp } from '@/lib/convex-server';
+import { api } from 'convex/_generated/api';
+import { cookies } from 'next/headers';
+import { getIronSession } from 'iron-session';
+import { sessionOptions, SessionData } from '@/lib/auth/session-config';
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: cliqId } = await params;
+    const user = await getCurrentUser();
+    if (!user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    // Fetch members via Convex
+    const members = await convexHttp.query(api.cliqs.getCliqMembers, {
+      cliqId: cliqId as any,
+    });
+
+    // Count this as activity
+    try {
+      const cookieStore = await cookies();
+      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
+      const res2 = new Response();
+      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
+      if (session && session.userId) {
+        session.lastActivityAt = Date.now();
+        await session.save();
+      }
+    } catch {}
+
+    return NextResponse.json({ members: members ?? [] });
+  } catch (err) {
+    console.error('[GET_CLIQ_MEMBERS_ERROR]', err);
+    return NextResponse.json({ error: 'Failed to fetch members' }, { status: 500 });
+  }
+}
+
+

--- a/src/app/api/invites/create/route.ts
+++ b/src/app/api/invites/create/route.ts
@@ -10,15 +10,13 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+export const runtime = "nodejs";
 import crypto from 'crypto';
 import { getCurrentUser } from '@/lib/auth/getCurrentUser';
 import { convexHttp } from '@/lib/convex-server';
 import { api } from 'convex/_generated/api';
 import { generateJoinCode } from '@/lib/auth/generateJoinCode';
-import { cookies } from 'next/headers';
-import { getIronSession } from 'iron-session';
-import { sessionOptions, SessionData } from '@/lib/auth/session-config';
-import { invalidateUser } from '@/lib/cache/userCache';
+import { bumpActivityAndInvalidate } from '@/lib/session-activity';
 
 export async function POST(request: NextRequest) {
   try {
@@ -105,17 +103,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Bump session activity and invalidate user cache
-    try {
-      const cookieStore = await cookies();
-      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
-      const res2 = new Response();
-      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
-      if (session && session.userId) {
-        session.lastActivityAt = Date.now();
-        await session.save();
-        await invalidateUser(String(session.userId));
-      }
-    } catch {}
+    await bumpActivityAndInvalidate();
 
     // TODO: Send email with link: ${BASE_URL}/invite/${invite.token}
     

--- a/src/app/api/posts/create/route.ts
+++ b/src/app/api/posts/create/route.ts
@@ -1,4 +1,5 @@
 export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
 
 /**
  * 🔐 APA-HARDENED ROUTE: POST /api/posts/create
@@ -31,10 +32,7 @@ import { api } from 'convex/_generated/api';
 import { getCurrentUser } from '@/lib/auth/getCurrentUser';
 // Note: Membership verification is now handled by Convex functions automatically
 import { z } from 'zod';
-import { cookies } from 'next/headers';
-import { getIronSession } from 'iron-session';
-import { sessionOptions, SessionData } from '@/lib/auth/session-config';
-import { invalidateUser } from '@/lib/cache/userCache';
+import { bumpActivityAndInvalidate } from '@/lib/session-activity';
 
 const schema = z.object({
   content: z.string().optional(),
@@ -86,17 +84,7 @@ export async function POST(req: Request) {
       expiresAt: expiresAt.getTime(),
     });
     // Bump session activity and invalidate cache
-    try {
-      const cookieStore = await cookies();
-      const req2 = new Request('http://local', { headers: { cookie: cookieStore.toString() } });
-      const res2 = new Response();
-      const session = await getIronSession<SessionData>(req2 as any, res2 as any, sessionOptions);
-      if (session && session.userId) {
-        session.lastActivityAt = Date.now();
-        await session.save();
-        await invalidateUser(String(session.userId));
-      }
-    } catch {}
+    await bumpActivityAndInvalidate();
 
     return NextResponse.json(post);
   } catch (err) {

--- a/src/components/cliqs/MembersModal.tsx
+++ b/src/components/cliqs/MembersModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from 'next/link';
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 interface Member {
@@ -33,7 +34,7 @@ export default function MembersModal({ cliqId, open, onClose, isOwner = false }:
         if (!res.ok) throw new Error("Failed to fetch members");
         return res.json();
       })
-      .then(data => setMembers(data.members || []))
+      .then(data => setMembers(Array.isArray(data.members) ? data.members : []))
       .catch(err => setError(err.message))
       .finally(() => setLoading(false));
   }, [cliqId, open]);
@@ -92,12 +93,46 @@ export default function MembersModal({ cliqId, open, onClose, isOwner = false }:
         <DialogTitle className="text-xl font-bold mb-2">Members</DialogTitle>
         {loading && <div className="py-4 text-center text-gray-500">Loading members...</div>}
         {error && <div className="py-4 text-center text-red-500">{error}</div>}
+        {!loading && !error && (
+          <div className="flex items-center justify-between mb-3">
+            <div className="text-sm text-gray-500">Cliq ID: {cliqId}</div>
+            <div className="flex items-center gap-2">
+              {isOwner && (
+                <button
+                  onClick={async () => {
+                    try {
+                      const url = `${window.location.origin}/cliqs/${cliqId}`;
+                      await navigator.clipboard.writeText(url);
+                      setFeedback({ type: 'success', message: 'Cliq link copied' });
+                      setTimeout(() => setFeedback(null), 1500);
+                    } catch {
+                      setFeedback({ type: 'error', message: 'Failed to copy link' });
+                      setTimeout(() => setFeedback(null), 2000);
+                    }
+                  }}
+                  className="px-3 py-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+                >
+                  Copy Cliq Link
+                </button>
+              )}
+              <Link
+                href={`/cliqs/${cliqId}/members`}
+                className="px-3 py-1 rounded bg-blue-50 hover:bg-blue-100 text-blue-700 text-sm"
+              >
+                Open Full Members Page
+              </Link>
+            </div>
+          </div>
+        )}
+        {!loading && !error && members.length === 0 && (
+          <div className="py-6 text-center text-gray-500">Currently no members.</div>
+        )}
         {feedback && (
           <div className={`mb-4 p-3 rounded ${feedback.type === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-600'}`}>
             {feedback.message}
           </div>
         )}
-        {!loading && !error && (
+        {!loading && !error && members.length > 0 && (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead>

--- a/src/lib/session-activity.ts
+++ b/src/lib/session-activity.ts
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers';
+import { getIronSession } from 'iron-session';
+import { sessionOptions, SessionData } from '@/lib/auth/session-config';
+import { invalidateUser } from '@/lib/cache/userCache';
+
+/**
+ * Updates session.lastActivityAt and invalidates the acting user's cache.
+ * Safe to call from API routes; swallows errors and returns whether it updated.
+ */
+export async function bumpActivityAndInvalidate(): Promise<boolean> {
+  try {
+    const session = await getIronSession<SessionData>(cookies(), sessionOptions);
+    if (session?.userId) {
+      session.lastActivityAt = Date.now();
+      await session.save();
+      await invalidateUser(String(session.userId));
+      return true;
+    }
+  } catch (error) {
+    console.error('[session-activity] Failed to bump activity', error);
+  }
+  return false;
+}
+
+

--- a/sync-dev.sh
+++ b/sync-dev.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+echo "📦 Exporting data from Prod (upbeat-hedgehog-998)..."
+npx convex export --deployment-name prod:upbeat-hedgehog-998 --path prod.zip
+
+echo "📥 Importing data into Dev (adorable-chicken-923)..."
+npx convex import --deployment-name dev:adorable-chicken-923 --replace prod.zip
+
+echo "✅ Dev database refreshed from Prod"


### PR DESCRIPTION
…ivity bumps\n\n- Restore absolute session expiry and null returns in getCurrentUser\n- Add /api/cliqs/[id]/members and empty-state UI; copy link + full page link\n- Mirror plan to account.plan + approve; save session on response\n- Activity bump + cache invalidation on posts/replies/join/leave/member-actions\n- Document SESSION_ABSOLUTE_MINUTES in README

# PR Checklist

- [ ] I followed the rules in `DEV_RULES.md`.
- [ ] I always enter the date when updating .md files.
- [ ] I did not delete any files. If something was unused, I moved it to `/deprecated/` and documented why.
- [ ] I confirmed the route/page/component I touched does not already exist in the repo.
- [ ] If I believed it was missing, I included search output (file path & line).
- [ ] I proved persistence by running the relevant Convex function in Dashboard and included a screenshot of the Data tab.
- [ ] I completed the flow QA checklist for the flow this PR touches.

---

## Description
Explain what this PR does and which flow(s) it touches.

## Testing
1. What flow you tested
2. Screenshot(s) from Convex Data tab
3. `npx convex whoami` output (dev or prod)

---
Updated: 09-17-25 / RT
